### PR TITLE
Various enhancements

### DIFF
--- a/zotelo.el
+++ b/zotelo.el
@@ -125,6 +125,12 @@ You can set this variable interactively with
   :type '(string :tag "Charset")
   :safe 'string-or-null-p)
 
+(defcustom zotelo-use-journal-abbreviation nil
+  "Use journal abbreviations for exporting bibliography."
+  :group 'zotelo
+  :type '(boolean :tag "Use journal abbreviation")
+  :safe 'booleanp)
+
 (defconst zotelo--get-zotero-database-js
   "var zotelo_zotero = Components.classes['@zotero.org/Zotero;1'].getService(Components.interfaces.nsISupports).wrappedJSObject;
 zotelo_zotero.getZoteroDatabase().path;")
@@ -221,7 +227,7 @@ if(zotelo_collection){
     zotelo_translator.setLocation(zotelo_file);
     zotelo_translator.setTranslator(zotelo_translator_id);
     zotelo_prefs.setBoolPref('recursiveCollections', true);
-    zotelo_translator.setDisplayOptions({'exportCharset': '%s'});
+    zotelo_translator.setDisplayOptions({'exportCharset': '%s', 'useJournalAbbreviation': %s});
     zotelo_translator.translate();
     zotelo_prefs.setBoolPref('recursiveCollections', zotelo_recColl);
     zotelo_out=':MozOK:';
@@ -459,6 +465,9 @@ Through an error if zotero collection has not been found by MozRepl"
         (file-name (file-name-nondirectory (file-name-sans-extension (buffer-file-name))))
         (translator (assoc zotelo-default-translator (zotelo--get-translators)))
         (charset zotelo-charset) charset-value
+        (journal-abbr (if zotelo-use-journal-abbreviation
+                          "true"
+                        "false"))
         all-colls-p cstr bib-last-change zotero-last-change com com1)
     (unless translator
       (error "Cannot find %s in Zotero's translators" zotelo-default-translator))
@@ -511,9 +520,9 @@ Through an error if zotero collection has not been found by MozRepl"
                (or (null check-zotero-change)
                    (null bib-last-change)
                    (time-less-p bib-last-change zotero-last-change)))
-      (setq cstr (format zotelo--export-collection-js bibfile id (cadr translator) charset-value))
-      (zotelo--message (format "Executing command: \n\n (moz-command (format zotelo--export-collection-js '%s' %s))\n\n translated as:\n %s\n"
-			       bibfile id cstr))
+      (setq cstr (format zotelo--export-collection-js bibfile id (cadr translator) charset-value journal-abbr))
+      (zotelo--message (format "Executing command: \n\n (moz-command (format zotelo--export-collection-js '%s' %s %s %s %s))\n\n translated as:\n %s\n"
+			       bibfile id (cadr translator) charset-value journal-abbr cstr))
       (message "Updating '%s' ..." (file-name-nondirectory bibfile))
       (setq com (split-string cstr "//split" t))
       (while (setq com1 (pop com))

--- a/zotelo.el
+++ b/zotelo.el
@@ -123,13 +123,13 @@ You can set this variable interactively with
 `zotelo-set-charset'."
   :group 'zotelo
   :type '(string :tag "Charset")
-  :safe t)
+  :safe 'string-or-null-p)
 
-(defvar zotelo--get-zotero-database-js
+(defconst zotelo--get-zotero-database-js
   "var zotelo_zotero = Components.classes['@zotero.org/Zotero;1'].getService(Components.interfaces.nsISupports).wrappedJSObject;
 zotelo_zotero.getZoteroDatabase().path;")
 
-(defvar zotelo--get-zotero-storage-js
+(defconst zotelo--get-zotero-storage-js
   "var zotelo_zotero = Components.classes['@zotero.org/Zotero;1'].getService(Components.interfaces.nsISupports).wrappedJSObject;
 zotelo_zotero.getStorageDirectory().path;")
 
@@ -154,7 +154,7 @@ zotelo_zotero.getStorageDirectory().path;")
       (goto-char (point-max))
       (insert (format "\n zotelo message [%s]\n %s\n" (current-time-string) str)))))
 
-(defvar zotelo--render-collection-js
+(defconst zotelo--render-collection-js
   "var zotelo_render_collection = function() {
     var R=%s;
     var Zotero = Components.classes['@zotero.org/Zotero;1'].getService(Components.interfaces.nsISupports).wrappedJSObject;
@@ -174,7 +174,7 @@ zotelo_zotero.getStorageDirectory().path;")
 "
   )
 
-(defvar zotelo--render-translators-js
+(defconst zotelo--render-translators-js
   "var zotelo_render_translators = function() {
     var R=%s;
     var Zotero = Components.classes['@zotero.org/Zotero;1'].getService(Components.interfaces.nsISupports).wrappedJSObject;
@@ -188,7 +188,7 @@ zotelo_zotero.getStorageDirectory().path;")
 ")
 
 
-(defvar zotelo--render-charsets-js
+(defconst zotelo--render-charsets-js
   "var R = %s;
 zoteloAllCharsets = CharsetMenu.getData().pinnedCharsets.concat(CharsetMenu.getData().otherCharsets);
 for each (var cs in zoteloAllCharsets) {
@@ -199,7 +199,7 @@ for each (var cs in zoteloAllCharsets) {
 ;;;; moz-repl splits long commands. Need to send it partially, but then errors
 ;;;; in first parts are not visible ... :(
 ;;;; todo: insert the check dirrectly in moz-command ??? 
-(defvar zotelo--export-collection-js
+(defconst zotelo--export-collection-js
   "
 var zotelo_filename=('%s');
 var zotelo_id = %s;
@@ -234,7 +234,7 @@ zotelo_out;
   "Command to be sent to zotero request export."
   )
 
-(defvar zotelo--dateModified-js
+(defconst zotelo--dateModified-js
   "var zotelo_zotero = Components.classes['@zotero.org/Zotero;1'].getService(Components.interfaces.nsISupports).wrappedJSObject;
 var zotelo_id = %s;
 var zotelo_collection = zotelo_zotero.Collections.get(zotelo_id);


### PR DESCRIPTION
I have enhanced zotelo with a couple of features:

* Fetch Zotero's translators from Zotero instead of hardcoding them in zotelo.el
* Add export option for character set
* Use Ascii encoding by default for bibtex as it doesn't support Unicode
* Add export option for journal abbreviations